### PR TITLE
feat: Add functionality to check network config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Available Commands:
   help                 Help about any command
   image                Get latest HPCR Image ID from IBM Cloud Image list
   validate-contract    Validate unencrypted contract
+  validate-network     Validate schema of network-config
 
 Flags:
   -h, --help   help for contract-cli
@@ -52,7 +53,8 @@ Use "contract-cli [command] --help" for more information about a command.
 6. Encrypt plain text or JSON data as per Hyper Protect format.
 7. Generate signed and encrypted contract for HPVS (with and without contract expiry).
 8. Get the image details of any available (default to latest) HPVS image in IBM Cloud.
-9. Validate unencrypted contracts for provisioning in HPVS. 
+9. Validate unencrypted contracts for provisioning in HPVS.
+10. Validate schema of network-config (for on-prem environment) for HPVS and HPCR RHVS.
 
 ## Documentation
 

--- a/cmd/validateNetwork.go
+++ b/cmd/validateNetwork.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/ibm-hyper-protect/contract-cli/common"
+	"github.com/ibm-hyper-protect/contract-go/network"
+	"github.com/spf13/cobra"
+)
+
+// validateNetworkConfigCmd represents the validate-networkConfig command
+var validateNetworkConfigCmd = &cobra.Command{
+	Use:   common.ValidateNetworkConfigParamName,
+	Short: common.ValidateNetworkConfigParamShortDescription,
+	Long:  common.ValidateNetworkConfigParamLongDescription,
+	Run: func(cmd *cobra.Command, args []string) {
+		networkConfigPath, err := validateInputNetworkConfig(cmd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !common.CheckFileFolderExists(networkConfigPath) {
+			log.Fatal("The path to networkConfig doesn't exist")
+		}
+
+		networkConfigData, err := common.ReadDataFromFile(networkConfigPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = network.HpcrVerifyNetworkConfig(networkConfigData)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Network Config Validated Successfully")
+	},
+}
+
+// init - cobra init function
+func init() {
+	rootCmd.AddCommand(validateNetworkConfigCmd)
+	validateNetworkConfigCmd.PersistentFlags().String(common.FileInFlagName, "", common.ValidateNetworkConfigInputFlagDescription)
+}
+
+// validateInputnetworkConfig - function to get network-config file
+func validateInputNetworkConfig(cmd *cobra.Command) (string, error) {
+	networkConfig, err := cmd.Flags().GetString(common.FileInFlagName)
+	if err != nil {
+		return "", err
+	}
+
+	return networkConfig, nil
+}

--- a/cmd/validateNetwork.go
+++ b/cmd/validateNetwork.go
@@ -36,7 +36,7 @@ var validateNetworkConfigCmd = &cobra.Command{
 		}
 
 		if !common.CheckFileFolderExists(networkConfigPath) {
-			log.Fatal("The path to networkConfig doesn't exist")
+			log.Fatal("The path to network-config doesn't exist")
 		}
 
 		networkConfigData, err := common.ReadDataFromFile(networkConfigPath)
@@ -48,7 +48,7 @@ var validateNetworkConfigCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Println("Network Config Validated Successfully")
+		fmt.Println("network-config validated successfully")
 	},
 }
 

--- a/cmd/validateNetwork_test.go
+++ b/cmd/validateNetwork_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ibm-hyper-protect/contract-cli/common"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	sampleValidateNetworkConfigInput = "../samples/network/network-config.yaml"
+)
+
+var (
+	sampleValidNetworkConfigCommand = []string{common.ValidateNetworkConfigParamName, "--in", sampleValidateNetworkConfigInput}
+)
+
+// Testcase to check if validate-networkconfig is able to validate network-config file
+func TestValidateNetworkConfigCmdSucess(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+
+	rootCmd.SetArgs(sampleValidNetworkConfigCommand)
+	err := validateNetworkConfigCmd.Execute()
+	assert.NoError(t, err)
+}

--- a/common/constants.go
+++ b/common/constants.go
@@ -129,4 +129,10 @@ Refer github.com/ibm-hyper-protect/contract-cli for details on features`
 	EncryptCsrFlagDescription            = "Path to CSR file"
 	EncryptExpiryDaysFlagName            = "expiry"
 	EncryptExpiryDaysFlagDescription     = "Expiry of the contract in number of days"
+
+	// Validate network-config
+	ValidateNetworkConfigParamName             = "validate-network"
+	ValidateNetworkConfigParamShortDescription = "Validate schema of network-config"
+	ValidateNetworkConfigParamLongDescription  = `Validate schema of network-config YAML file`
+	ValidateNetworkConfigInputFlagDescription  = "Path to network-config file"
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -381,3 +381,29 @@ The following is an example to validate a contract.
 ```bash
 $ contract-cli validate-contract --in samples/contract.yaml
 ```
+
+### validate-network
+
+This feature will help to validate if the network-config schema is valid or not schematically.
+
+```bash
+$ contract-cli validate-network --help
+Validate schema of network-config
+
+Usage:
+  contract-cli validate-network [flags]
+
+Flags:
+  -h, --help        help for validate-network
+      --in string   Path to network-config file
+```
+
+To validate a network-config.
+```bash
+$ contract-cli validate-network --in <path-to-network-config>
+```
+
+The following is an example to validate a contract.
+```bash
+$ contract-cli validate-network --in samples/network-config.yaml
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ibm-hyper-protect/contract-cli
 go 1.22.4
 
 require (
-	github.com/ibm-hyper-protect/contract-go v1.13.1
+	github.com/ibm-hyper-protect/contract-go v1.13.4
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -3,12 +3,6 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ibm-hyper-protect/contract-go v1.13.0 h1:O+bIYEh4Wn+N5wibp+RWrtBf8hygGL+J1KmVkAeVfd0=
-github.com/ibm-hyper-protect/contract-go v1.13.0/go.mod h1:qlZzytwNlmXjPndkktIL1kWHGGVfWgWuPfpaiUuqoUQ=
-github.com/ibm-hyper-protect/contract-go v1.13.1 h1:MvILJLmEIkMCbQXS2O4Kd6xKG3nt2W2+eLoNu75ezjY=
-github.com/ibm-hyper-protect/contract-go v1.13.1/go.mod h1:UxSch2vJsa7jmHYcE+TXM2GUtoqTG6XXGu3D/r/zsaY=
-github.com/ibm-hyper-protect/contract-go v1.13.4 h1:Tega8ovUBTgE9AOMHGqcs8n2HFC5Vfzb5Kr7z6dDVak=
-github.com/ibm-hyper-protect/contract-go v1.13.4/go.mod h1:UxSch2vJsa7jmHYcE+TXM2GUtoqTG6XXGu3D/r/zsaY=
 github.com/ibm-hyper-protect/contract-go v1.13.5 h1:JRnRW90lwTCHsNTFJWJYCaHRvcTrSg79P3BTxg2ipQQ=
 github.com/ibm-hyper-protect/contract-go v1.13.5/go.mod h1:UxSch2vJsa7jmHYcE+TXM2GUtoqTG6XXGu3D/r/zsaY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,8 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ibm-hyper-protect/contract-go v1.13.0 h1:O+bIYEh4Wn+N5wibp+RWrtBf8hygGL+J1KmVkAeVfd0=
-github.com/ibm-hyper-protect/contract-go v1.13.0/go.mod h1:qlZzytwNlmXjPndkktIL1kWHGGVfWgWuPfpaiUuqoUQ=
-github.com/ibm-hyper-protect/contract-go v1.13.1 h1:MvILJLmEIkMCbQXS2O4Kd6xKG3nt2W2+eLoNu75ezjY=
-github.com/ibm-hyper-protect/contract-go v1.13.1/go.mod h1:UxSch2vJsa7jmHYcE+TXM2GUtoqTG6XXGu3D/r/zsaY=
+github.com/ibm-hyper-protect/contract-go v1.13.4 h1:Tega8ovUBTgE9AOMHGqcs8n2HFC5Vfzb5Kr7z6dDVak=
+github.com/ibm-hyper-protect/contract-go v1.13.4/go.mod h1:UxSch2vJsa7jmHYcE+TXM2GUtoqTG6XXGu3D/r/zsaY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/samples/network/network-config.yaml
+++ b/samples/network/network-config.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  ethernets:
+    enc1:
+      dhcp4: false
+      addresses:
+        - 192.168.122.110/24 
+      gateway4: 192.168.122.1
+      nameservers:
+        addresses:
+          - 8.8.8.8


### PR DESCRIPTION
## Description

- Added function to validate network schema.
- This feature will help to validate if the network-config schema is valid or not schematically.

Test results:

```
go test ./... -v
?       github.com/ibm-hyper-protect/contract-cli       [no test files]
=== RUN   TestBase64TgzCmdSuccessPlain
Successfully stored tar tgz data
--- PASS: TestBase64TgzCmdSuccessPlain (0.00s)
=== RUN   TestBase64TgzCmdSuccessEncrypted
Successfully stored tar tgz data
--- PASS: TestBase64TgzCmdSuccessEncrypted (0.04s)
=== RUN   TestBase64CmdSuccess1
successfully generated Base64
--- PASS: TestBase64CmdSuccess1 (0.00s)
=== RUN   TestBase64CmdSuccess2
successfully generated Base64
--- PASS: TestBase64CmdSuccess2 (0.00s)
=== RUN   TestDecryptAttestationCmdSucess
Successfully decrypted attestation records
--- PASS: TestDecryptAttestationCmdSucess (0.03s)
=== RUN   TestDownloadCertificatesCmdSuccess
Successfully stored certificates
--- PASS: TestDownloadCertificatesCmdSuccess (2.30s)
=== RUN   TestEncryptStringCmdText
Successfully stored encrypted text
--- PASS: TestEncryptStringCmdText (0.08s)
=== RUN   TestEncryptStringCmdJson
Successfully stored encrypted text
--- PASS: TestEncryptStringCmdJson (0.05s)
=== RUN   TestEncryptCmdText
Successfully generated signed and encrypted contract
--- PASS: TestEncryptCmdText (0.17s)
=== RUN   TestEncryptCmdTextContractExpiry
Successfully generated signed and encrypted contract
--- PASS: TestEncryptCmdTextContractExpiry (0.17s)
=== RUN   TestGetCertificateCmdSuccess
Successfully added encryption certificate 
--- PASS: TestGetCertificateCmdSuccess (0.00s)
=== RUN   TestImageCmdSuccess1
Successfully stored HPCR image details
--- PASS: TestImageCmdSuccess1 (0.00s)
=== RUN   TestImageCmdSuccess2
Successfully stored HPCR image details
--- PASS: TestImageCmdSuccess2 (0.00s)
=== RUN   TestImageCmdSuccessWithoutVersion
Successfully stored HPCR image details
--- PASS: TestImageCmdSuccessWithoutVersion (0.00s)
=== RUN   TestValidateContractCmdSucess
True
--- PASS: TestValidateContractCmdSucess (0.04s)
=== RUN   TestValidateNetworkConfigCmdSucess
Network Config Validated Successfully
--- PASS: TestValidateNetworkConfigCmdSucess (0.00s)
PASS
ok      github.com/ibm-hyper-protect/contract-cli/cmd   4.384s
=== RUN   TestCheckFileFolderExists
--- PASS: TestCheckFileFolderExists (0.00s)
=== RUN   TestReadDataFromFile
--- PASS: TestReadDataFromFile (0.00s)
=== RUN   TestWriteDataToFile
--- PASS: TestWriteDataToFile (0.00s)
=== RUN   TestExecCommand
--- PASS: TestExecCommand (0.01s)
=== RUN   TestOpensslCheck
--- PASS: TestOpensslCheck (0.01s)
=== RUN   TestGetPrivateKeyNoKey
--- PASS: TestGetPrivateKeyNoKey (0.00s)
=== RUN   TestGetPrivateKey
--- PASS: TestGetPrivateKey (0.24s)
=== RUN   TestGeneratePrivateKey
--- PASS: TestGeneratePrivateKey (0.38s)
=== RUN   TestGetDataFromFileWithData
--- PASS: TestGetDataFromFileWithData (0.00s)
=== RUN   TestGetDataFromFileWithoutData
--- PASS: TestGetDataFromFileWithoutData (0.00s)
PASS
ok      github.com/ibm-hyper-protect/contract-cli/common        1.268s
```

## Checklist

- [x] I have opened an issue for this change
- [x] The issue has been approved by a maintainer
- [x] I have added tests or explained on feature / bug
- [x] I have run `make tidy`, `make test` and it passes

Closes: #28 
