### PR TITLE
feat: Sealed Secret Support in contract-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ This CLI is for **developers, DevOps engineers, and platform teams** who need to
   - Validate contract schemas
   - Create Gzipped & Encoded initdata for IBM Confidential Computing Containers Peer Pod
 
+- **Sealed Secret Management**
+  - Generate sealed secrets for CCCO workload and environment sections
+  - Automatic key generation or use custom encryption/signing keys
+  - Output sealed secrets with decryption and verification keys
+
 - **Archive Management**
   - Generate Base64 tar archives of `docker-compose.yaml` or `pods.yaml`
   - Support encrypted base64 tar generation
@@ -387,6 +392,50 @@ contract-cli encrypt \
   --out encrypted-contract.yaml
 ```
 
+### Generate Sealed Secrets for CCCO
+
+```bash
+# Generate sealed secret for environment variables
+contract-cli sealed-secret \
+  --in "value123" \
+  --type env \
+  --out sealed-secret.txt
+
+# Generate sealed secret for workload data
+contract-cli sealed-secret \
+  --in workload-secret-data \
+  --type workload \
+  --out sealed-workload.txt
+
+# Generate sealed secret from file
+contract-cli sealed-secret \
+  --in secrets.txt \
+  --type env \
+  --out sealed-secret.txt
+
+# Generate sealed secret with custom encryption and signing keys
+
+openssl genrsa -out encryption.pem 2048
+openssl genrsa -out signing.pem 2048
+
+contract-cli sealed-secret \
+  --in "value123" \
+  --type env \
+  --encryptionkey encryption.pem \
+  --signingkey signing.pem \
+  --out sealed-secret.txt
+
+# Read secret from stdin
+echo "value123" | contract-cli sealed-secret \
+  --in - \
+  --type env
+```
+
+The sealed secret output includes:
+- The sealed secret data (for use in contract)
+- `SECRET_DECRYPTION_KEY` - Private key for decryption (keep secure)
+- `SECRET_VERIFICATION_KEY` - Public key for verification
+
 ## Usage
 
 ```bash
@@ -413,6 +462,7 @@ Available Commands:
   encrypt-string                  Encrypt string in IBM Confidential Computing format
   get-certificate                 Extract specific certificate version from download output
   help                            Help about any command
+  sealed-secret                   Generate sealed secret for CCCO
   image                           Get IBM Confidential Computing Container Runtime image details from IBM Cloud
   initdata                        Gzip and Encoded initdata annotation
   list-encryptioncert-versions    List available encryption certificate versions

--- a/cmd/sealedSecret.go
+++ b/cmd/sealedSecret.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/ibm-hyper-protect/contract-cli/common"
+	"github.com/ibm-hyper-protect/contract-cli/lib/sealedSecret"
+	"github.com/spf13/cobra"
+)
+
+// sealedSecretCmd represents the sealed-secret command
+var sealedSecretCmd = &cobra.Command{
+	Use:   sealedSecret.ParameterName,
+	Short: sealedSecret.ParameterShortDescription,
+	Long:  sealedSecret.ParameterLongDescription,
+	Run: func(cmd *cobra.Command, args []string) {
+		inputData, secretType, outputPath, encryptionKeyPath, signingKeyPath, err := sealedSecret.ValidateInput(cmd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		sealedSecretData, decryptionKey, verificationKey, _, _, err := sealedSecret.GenerateSealedSecret(inputData, secretType, encryptionKeyPath, signingKeyPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = sealedSecret.Output(sealedSecretData, decryptionKey, verificationKey, outputPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+// init - cobra init function
+func init() {
+	rootCmd.AddCommand(sealedSecretCmd)
+
+	requiredFlags := map[string]bool{
+		"in":   true,
+		"type": true,
+	}
+
+	sealedSecretCmd.PersistentFlags().String(sealedSecret.InputFlagName, "", sealedSecret.InputFlagDescription)
+	sealedSecretCmd.PersistentFlags().String(sealedSecret.TypeFlagName, "", sealedSecret.TypeFlagDescription)
+	sealedSecretCmd.PersistentFlags().String(sealedSecret.OutputFlagName, "", sealedSecret.OutputFlagDescription)
+	sealedSecretCmd.PersistentFlags().String(sealedSecret.EncryptionKeyFlagName, "", sealedSecret.EncryptionKeyFlagDescription)
+	sealedSecretCmd.PersistentFlags().String(sealedSecret.SigningKeyFlagName, "", sealedSecret.SigningKeyFlagDescription)
+
+	common.SetCustomHelpTemplate(sealedSecretCmd, requiredFlags)
+	common.SetCustomErrorTemplate(sealedSecretCmd)
+}

--- a/cmd/sealedSecret_test.go
+++ b/cmd/sealedSecret_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ibm-hyper-protect/contract-cli/lib/sealedSecret"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	sampleSealedSecretInput = "value123"
+)
+
+// TestSealedSecretCmd_EnvType tests if sealed secret command can generate env type sealed secret
+func TestSealedSecretCmd_EnvType(t *testing.T) {
+	// Create unique output file for this test
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "sealed-secret-env-output.txt")
+
+	// Capture output
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+
+	rootCmd.SetArgs([]string{sealedSecret.ParameterName, "--in", sampleSealedSecretInput, "--type", "env", "--out", outputPath})
+	err := sealedSecretCmd.Execute()
+
+	assert.NoError(t, err)
+
+	// Verify output file was created and contains expected content
+	content, readErr := os.ReadFile(outputPath)
+	assert.NoError(t, readErr)
+	assert.Contains(t, string(content), "Sealed Secret:")
+	assert.Contains(t, string(content), "SECRET_DECRYPTION_KEY=")
+	assert.Contains(t, string(content), "SECRET_VERIFICATION_KEY=")
+	// t.TempDir() automatically cleans up after test
+}
+
+// TestSealedSecretCmd_WorkloadType tests if sealed secret command can generate workload type sealed secret
+func TestSealedSecretCmd_WorkloadType(t *testing.T) {
+	// Create unique output file for this test
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "sealed-secret-workload-output.txt")
+
+	// Capture output
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+
+	rootCmd.SetArgs([]string{sealedSecret.ParameterName, "--in", sampleSealedSecretInput, "--type", "workload", "--out", outputPath})
+	err := sealedSecretCmd.Execute()
+
+	assert.NoError(t, err)
+
+	// Verify output file was created and contains expected content
+	content, readErr := os.ReadFile(outputPath)
+	assert.NoError(t, readErr)
+	assert.Contains(t, string(content), "Sealed Secret:")
+	assert.Contains(t, string(content), "SECRET_DECRYPTION_KEY=")
+	assert.Contains(t, string(content), "SECRET_VERIFICATION_KEY=")
+	// t.TempDir() automatically cleans up after test
+}
+
+// TestSealedSecretCmd_CommandProperties tests command properties
+func TestSealedSecretCmd_CommandProperties(t *testing.T) {
+	assert.NotNil(t, sealedSecretCmd)
+	assert.Equal(t, sealedSecret.ParameterName, sealedSecretCmd.Use)
+	assert.Equal(t, sealedSecret.ParameterShortDescription, sealedSecretCmd.Short)
+	assert.Equal(t, sealedSecret.ParameterLongDescription, sealedSecretCmd.Long)
+}
+
+// TestSealedSecretCmd_Flags tests if all required flags are present
+func TestSealedSecretCmd_Flags(t *testing.T) {
+	flags := []string{
+		sealedSecret.InputFlagName,
+		sealedSecret.TypeFlagName,
+		sealedSecret.OutputFlagName,
+		sealedSecret.EncryptionKeyFlagName,
+		sealedSecret.SigningKeyFlagName,
+	}
+
+	for _, flagName := range flags {
+		flag := sealedSecretCmd.Flags().Lookup(flagName)
+		assert.NotNil(t, flag, "Expected flag '%s' to be present", flagName)
+	}
+}
+
+// TestSealedSecretCmd_FlagShorthands tests that flags don't have shorthands (using PersistentFlags)
+func TestSealedSecretCmd_FlagShorthands(t *testing.T) {
+	inputFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.InputFlagName)
+	assert.NotNil(t, inputFlag)
+	assert.Equal(t, "", inputFlag.Shorthand)
+
+	typeFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.TypeFlagName)
+	assert.NotNil(t, typeFlag)
+	assert.Equal(t, "", typeFlag.Shorthand)
+
+	outputFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.OutputFlagName)
+	assert.NotNil(t, outputFlag)
+	assert.Equal(t, "", outputFlag.Shorthand)
+
+	encKeyFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.EncryptionKeyFlagName)
+	assert.NotNil(t, encKeyFlag)
+	assert.Equal(t, "", encKeyFlag.Shorthand)
+
+	signKeyFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.SigningKeyFlagName)
+	assert.NotNil(t, signKeyFlag)
+	assert.Equal(t, "", signKeyFlag.Shorthand)
+}
+
+// TestSealedSecretCmd_FlagDefaults tests flag default values
+func TestSealedSecretCmd_FlagDefaults(t *testing.T) {
+	inputFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.InputFlagName)
+	assert.NotNil(t, inputFlag)
+	assert.Equal(t, "", inputFlag.DefValue)
+
+	typeFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.TypeFlagName)
+	assert.NotNil(t, typeFlag)
+	assert.Equal(t, "", typeFlag.DefValue)
+
+	outputFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.OutputFlagName)
+	assert.NotNil(t, outputFlag)
+	assert.Equal(t, "", outputFlag.DefValue)
+
+	encKeyFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.EncryptionKeyFlagName)
+	assert.NotNil(t, encKeyFlag)
+	assert.Equal(t, "", encKeyFlag.DefValue)
+
+	signKeyFlag := sealedSecretCmd.Flags().Lookup(sealedSecret.SigningKeyFlagName)
+	assert.NotNil(t, signKeyFlag)
+	assert.Equal(t, "", signKeyFlag.DefValue)
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Complete command reference and usage guide for the IBM Confidential Computing Co
   - [get-certificate](#get-certificate)
   - [image](#image)
   - [list-encryptioncert-versions](#list-encryptioncert-versions)
+  - [sealed-secret](#sealed-secret)
   - [validate-contract](#validate-contract)
   - [validate-network](#validate-network)
   - [validate-encryption-certificate](#validate-encryption-certificate)
@@ -909,6 +910,77 @@ contract-cli validate-encryption-certificate --in encryption-cert.crt
 ```bash
 cat encryption-cert.crt | contract-cli validate-encryption-certificate --in -
 ```
+
+---
+
+### sealed-secret
+Generate sealed secrets for IBM Confidential Computing Containers for Red Hat OpenShift Container Platform (CCCO).
+
+#### Usage
+
+```bash
+contract-cli sealed-secret [flags]
+```
+
+#### Flags
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--in` | string | Yes | Secret for sealing (provide as string or file path, use '-' for standard input) |
+| `--type` | string | Yes | Type of secret: 'env' for env section of contract or 'workload' for workload section of contract |
+| `--out` | string | No | Path to save sealed secret output (prints to stdout if not specified) |
+| `--encryptionkey` | string | No | Path to RSA private key for encryption (generates new key if not provided) |
+| `--signingkey` | string | No | Path to RSA private key for signing (generates new key if not provided) |
+| `-h, --help` | - | No | Display help information |
+
+#### Examples
+
+**Generate sealed secret for env section:**
+```bash
+contract-cli sealed-secret \
+  --in "value123" \
+  --type env \
+  --out sealed-secret.txt
+```
+
+**Generate sealed secret for workload section:**
+```bash
+contract-cli sealed-secret \
+  --in workload-secret-data \
+  --type workload \
+  --out sealed-workload.txt
+```
+
+**Generate sealed secret from file:**
+```bash
+contract-cli sealed-secret \
+  --in secrets.txt \
+  --type env \
+  --out sealed-secret.txt
+```
+
+**Generate sealed secret with custom encryption and signing keys:**
+```bash
+contract-cli sealed-secret \
+  --in "value123" \
+  --type env \
+  --encryptionkey encryption.key \
+  --signingkey signing.key \
+  --out sealed-secret.txt
+```
+
+**Read secret from stdin:**
+```bash
+echo "value123" | contract-cli sealed-secret \
+  --in - \
+  --type env
+```
+
+**Output format:**
+The command outputs:
+- The sealed secret data (for use in contract)
+- `SECRET_DECRYPTION_KEY` - Private key for decryption (keep secure)
+- `SECRET_VERIFICATION_KEY` - Public key for verification
 
 ---
 

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ibm-hyper-protect/contract-go/v2 v2.23.0 h1:pFzSzamtaD7Akf7rrM/yDQZmu1fS4/p7U7hFanbdRpY=
-github.com/ibm-hyper-protect/contract-go/v2 v2.23.0/go.mod h1:tbxT+1Xpl4jyYhK2scBO/OTl7/iM2HOoAQxkjdbnY7A=
 github.com/ibm-hyper-protect/contract-go/v2 v2.26.0 h1:2f0xIZ+OLujVgX6f0Ic5Q+Q5AJWt6q/SHRlAJ6ZVcQ8=
 github.com/ibm-hyper-protect/contract-go/v2 v2.26.0/go.mod h1:tbxT+1Xpl4jyYhK2scBO/OTl7/iM2HOoAQxkjdbnY7A=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/lib/sealedSecret/sealedSecret.go
+++ b/lib/sealedSecret/sealedSecret.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sealedSecret
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ibm-hyper-protect/contract-cli/common"
+	"github.com/ibm-hyper-protect/contract-go/v2/secrets"
+	"github.com/spf13/cobra"
+)
+
+const (
+	ParameterName             = "sealed-secret"
+	ParameterShortDescription = "Generate sealed secret for CCCO"
+	ParameterLongDescription  = `Generate a sealed secret for IBM Confidential Computing Containers for Red Hat Openshift Container Platform.
+
+Creates a sealed secret that can be used in workload or environment sections
+of your contract. The secret can be provided as a string or read from a file.`
+
+	InputFlagName        = "in"
+	InputFlagDescription = "Secret for sealing (provide as string or file path, use '-' for standard input)"
+
+	TypeFlagName        = "type"
+	TypeFlagDescription = "Type of secret: 'env' for env section of contract or 'workload' for workload section of contract"
+
+	OutputFlagName        = "out"
+	OutputFlagDescription = "Path to save sealed secret output (optional, prints to stdout if not specified)"
+
+	EncryptionKeyFlagName        = "encryptionkey"
+	EncryptionKeyFlagDescription = "Path to RSA private key for encryption (optional, generates new key if not provided)"
+
+	SigningKeyFlagName        = "signingkey"
+	SigningKeyFlagDescription = "Path to RSA private key for signing (optional, generates new key if not provided)"
+)
+
+// ValidateInput - function to validate inputs of sealed-secret
+func ValidateInput(cmd *cobra.Command) (string, string, string, string, string, error) {
+	inputData, err := cmd.Flags().GetString(InputFlagName)
+	if err != nil {
+		return "", "", "", "", "", err
+	}
+
+	if inputData == "" {
+		err := fmt.Errorf("Error: required flag '--in' is missing")
+		common.SetMandatoryFlagError(cmd, err)
+	}
+
+	// Validate stdin input conflicts
+	common.ValidateStdinInput(cmd, inputData)
+
+	secretType, err := cmd.Flags().GetString(TypeFlagName)
+	if err != nil {
+		return "", "", "", "", "", err
+	}
+
+	if secretType == "" {
+		err := fmt.Errorf("Error: required flag '--type' is missing")
+		common.SetMandatoryFlagError(cmd, err)
+	}
+
+	// Validate type value
+	if secretType != "env" && secretType != "workload" {
+		err := fmt.Errorf("Error: invalid value for '--type'. Must be 'env' or 'workload'")
+		common.SetMandatoryFlagError(cmd, err)
+	}
+
+	outputPath, err := cmd.Flags().GetString(OutputFlagName)
+	if err != nil {
+		return "", "", "", "", "", err
+	}
+
+	encryptionKeyPath, err := cmd.Flags().GetString(EncryptionKeyFlagName)
+	if err != nil {
+		return "", "", "", "", "", err
+	}
+
+	signingKeyPath, err := cmd.Flags().GetString(SigningKeyFlagName)
+	if err != nil {
+		return "", "", "", "", "", err
+	}
+
+	return inputData, secretType, outputPath, encryptionKeyPath, signingKeyPath, nil
+}
+
+// GenerateSealedSecret - function to generate sealed secret using contract-go SealSecret API
+// Returns: sealedSecret, decryptionKeyPEM, verificationKeyPEM, inputSecretSha, encryptedSecretSha, error
+func GenerateSealedSecret(inputDataPath, secretType, encryptionKeyPath, signingKeyPath string) (string, string, string, string, string, error) {
+	var inputData string
+	var err error
+
+	// Handle stdin input
+	if inputDataPath == "-" {
+		inputData, err = common.ReadDataFromStdin()
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("unable to read input from standard input: %w", err)
+		}
+	} else {
+		// Check if input is a file path
+		if common.CheckFileFolderExists(inputDataPath) {
+			inputData, err = common.ReadDataFromFile(inputDataPath)
+			if err != nil {
+				return "", "", "", "", "", fmt.Errorf("unable to read input from file: %w", err)
+			}
+		} else {
+			// Treat as direct string input
+			inputData = inputDataPath
+		}
+	}
+
+	// Read encryption key content if path is provided
+	var encryptionKeyContent string
+	if encryptionKeyPath != "" {
+		encKeyStr, err := common.GetDataFromFile(encryptionKeyPath)
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("failed to read encryption key from file: %w", err)
+		}
+		encryptionKeyContent = encKeyStr
+	}
+
+	// Read signing key content if path is provided
+	var signingKeyContent string
+	if signingKeyPath != "" {
+		signKeyStr, err := common.GetDataFromFile(signingKeyPath)
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("failed to read signing key from file: %w", err)
+		}
+		signingKeyContent = signKeyStr
+	}
+
+	// Call the SealSecret API from contract-go secrets package
+	// The function now accepts PEM string content directly and returns multiple values
+	sealedSecret, decryptionKey, verificationKey, inputSecretSha, encryptedSecretSha, err := secrets.HpccSealedSecret(
+		inputData,
+		secretType,
+		encryptionKeyContent,
+		signingKeyContent,
+	)
+	if err != nil {
+		return "", "", "", "", "", fmt.Errorf("failed to seal secret: %w", err)
+	}
+
+	return sealedSecret, decryptionKey, verificationKey, inputSecretSha, encryptedSecretSha, nil
+}
+
+// Output - function to output sealed secret and keys
+func Output(sealedSecret, decryptionKeyPEM, verificationKeyPEM, outputPath string) error {
+	// Format keys with escaped newlines (replace actual newlines with \n)
+	decryptionKeyFormatted := formatKeyWithEscapedNewlines(decryptionKeyPEM)
+	verificationKeyFormatted := formatKeyWithEscapedNewlines(verificationKeyPEM)
+
+	// Format the output as shell variable assignments
+	output := fmt.Sprintf("Sealed Secret:\n%s\n\nSECRET_DECRYPTION_KEY=%s\n\nSECRET_VERIFICATION_KEY=%s",
+		sealedSecret,
+		decryptionKeyFormatted,
+		verificationKeyFormatted)
+
+	if outputPath != "" {
+		err := common.WriteDataToFile(outputPath, output)
+		if err != nil {
+			return fmt.Errorf("failed to write sealed secret to file: %w", err)
+		}
+		fmt.Printf("Sealed secret and keys written to: %s\n", outputPath)
+	} else {
+		// Print to stdout if no output path specified
+		fmt.Println(output)
+	}
+
+	return nil
+}
+
+// formatKeyWithEscapedNewlines converts actual newlines in a key to escaped newlines (\n)
+// This matches the format: cat key.pem | tr '\n' '\\' | sed s/\\\\/\\\\n/g
+func formatKeyWithEscapedNewlines(key string) string {
+	// Replace actual newlines with the literal string "\n"
+	return strings.ReplaceAll(key, "\n", "\\n")
+}

--- a/lib/sealedSecret/sealedSecret_test.go
+++ b/lib/sealedSecret/sealedSecret_test.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sealedSecret
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testSecretData     = "value123"
+	testOutputPath     = "../../build/test_sealedsecret_output.txt"
+	testInvalidPath    = "../../build/file/file_not_exists.txt"
+	testSecretFilePath = "../../build/test_secret.txt"
+)
+
+// TestValidateInput_Success tests ValidateInput with all required flags
+func TestValidateInput_Success(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(InputFlagName, testSecretData, "")
+	cmd.Flags().String(TypeFlagName, "env", "")
+	cmd.Flags().String(OutputFlagName, testOutputPath, "")
+	cmd.Flags().String(EncryptionKeyFlagName, "", "")
+	cmd.Flags().String(SigningKeyFlagName, "", "")
+
+	inputData, secretType, outputPath, encKeyPath, signKeyPath, err := ValidateInput(cmd)
+
+	assert.NoError(t, err)
+	assert.Equal(t, testSecretData, inputData)
+	assert.Equal(t, "env", secretType)
+	assert.Equal(t, testOutputPath, outputPath)
+	assert.Equal(t, "", encKeyPath)
+	assert.Equal(t, "", signKeyPath)
+}
+
+// TestValidateInput_WorkloadType tests ValidateInput with workload type
+func TestValidateInput_WorkloadType(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(InputFlagName, testSecretData, "")
+	cmd.Flags().String(TypeFlagName, "workload", "")
+	cmd.Flags().String(OutputFlagName, "", "")
+	cmd.Flags().String(EncryptionKeyFlagName, "", "")
+	cmd.Flags().String(SigningKeyFlagName, "", "")
+
+	inputData, secretType, outputPath, encKeyPath, signKeyPath, err := ValidateInput(cmd)
+
+	assert.NoError(t, err)
+	assert.Equal(t, testSecretData, inputData)
+	assert.Equal(t, "workload", secretType)
+	assert.Equal(t, "", outputPath)
+	assert.Equal(t, "", encKeyPath)
+	assert.Equal(t, "", signKeyPath)
+}
+
+// TestValidateInput_WithAllOptionalFlags tests ValidateInput with all optional flags
+func TestValidateInput_WithAllOptionalFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(InputFlagName, testSecretData, "")
+	cmd.Flags().String(TypeFlagName, "env", "")
+	cmd.Flags().String(OutputFlagName, testOutputPath, "")
+	cmd.Flags().String(EncryptionKeyFlagName, "/tmp/enc.key", "")
+	cmd.Flags().String(SigningKeyFlagName, "/tmp/sign.key", "")
+
+	inputData, secretType, outputPath, encKeyPath, signKeyPath, err := ValidateInput(cmd)
+
+	assert.NoError(t, err)
+	assert.Equal(t, testSecretData, inputData)
+	assert.Equal(t, "env", secretType)
+	assert.Equal(t, testOutputPath, outputPath)
+	assert.Equal(t, "/tmp/enc.key", encKeyPath)
+	assert.Equal(t, "/tmp/sign.key", signKeyPath)
+}
+
+// TestValidateInput_WithoutFlags tests ValidateInput when flags are not set
+func TestValidateInput_WithoutFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	_, _, _, _, _, err := ValidateInput(cmd)
+	assert.Error(t, err)
+}
+
+// TestGenerateSealedSecret_EnvType tests GenerateSealedSecret with env type
+func TestGenerateSealedSecret_EnvType(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, inputSha, encryptedSha, err := GenerateSealedSecret(testSecretData, "env", "", "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sealedSecret)
+	assert.NotEmpty(t, decryptionKey)
+	assert.NotEmpty(t, verificationKey)
+	assert.NotEmpty(t, inputSha)
+	assert.NotEmpty(t, encryptedSha)
+}
+
+// TestGenerateSealedSecret_WorkloadType tests GenerateSealedSecret with workload type
+func TestGenerateSealedSecret_WorkloadType(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, _, _, err := GenerateSealedSecret("workload-secret-data", "workload", "", "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sealedSecret)
+	assert.NotEmpty(t, decryptionKey)
+	assert.NotEmpty(t, verificationKey)
+}
+
+// TestGenerateSealedSecret_InvalidType tests GenerateSealedSecret with invalid type
+func TestGenerateSealedSecret_InvalidType(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, inputSha, encryptedSha, err := GenerateSealedSecret(testSecretData, "invalid", "", "")
+	assert.Error(t, err)
+	assert.Empty(t, sealedSecret)
+	assert.Empty(t, decryptionKey)
+	assert.Empty(t, verificationKey)
+	assert.Empty(t, inputSha)
+	assert.Empty(t, encryptedSha)
+	assert.Contains(t, err.Error(), "invalid secret type")
+}
+
+// TestGenerateSealedSecret_WithFile tests GenerateSealedSecret with file input
+func TestGenerateSealedSecret_WithFile(t *testing.T) {
+	// Create a temporary file with test data
+	tmpDir := "../../build"
+	os.MkdirAll(tmpDir, 0755)
+	testFile := filepath.Join(tmpDir, "test_secret.txt")
+	testData := "test123"
+
+	err := os.WriteFile(testFile, []byte(testData), 0644)
+	assert.NoError(t, err)
+	defer os.Remove(testFile)
+
+	sealedSecret, decryptionKey, verificationKey, _, _, err := GenerateSealedSecret(testFile, "env", "", "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sealedSecret)
+	assert.NotEmpty(t, decryptionKey)
+	assert.NotEmpty(t, verificationKey)
+}
+
+// TestGenerateSealedSecret_InvalidFilePath tests GenerateSealedSecret with invalid file path
+// Note: Invalid file paths are treated as direct string input, so this will succeed
+func TestGenerateSealedSecret_InvalidFilePath(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, _, _, err := GenerateSealedSecret(testInvalidPath, "env", "", "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sealedSecret)
+	assert.NotEmpty(t, decryptionKey)
+	assert.NotEmpty(t, verificationKey)
+}
+
+// TestGenerateSealedSecret_InvalidEncryptionKeyPath tests with invalid encryption key path
+func TestGenerateSealedSecret_InvalidEncryptionKeyPath(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, inputSha, encryptedSha, err := GenerateSealedSecret(testSecretData, "env", testInvalidPath, "")
+	assert.Error(t, err)
+	assert.Empty(t, sealedSecret)
+	assert.Empty(t, decryptionKey)
+	assert.Empty(t, verificationKey)
+	assert.Empty(t, inputSha)
+	assert.Empty(t, encryptedSha)
+}
+
+// TestGenerateSealedSecret_InvalidSigningKeyPath tests with invalid signing key path
+func TestGenerateSealedSecret_InvalidSigningKeyPath(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, inputSha, encryptedSha, err := GenerateSealedSecret(testSecretData, "env", "", testInvalidPath)
+	assert.Error(t, err)
+	assert.Empty(t, sealedSecret)
+	assert.Empty(t, decryptionKey)
+	assert.Empty(t, verificationKey)
+	assert.Empty(t, inputSha)
+	assert.Empty(t, encryptedSha)
+}
+
+// TestOutput_WithFilePath tests Output function with valid file path
+func TestOutput_WithFilePath(t *testing.T) {
+	sealedSecret := "sealed-secret-data"
+	decryptionKey := "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+	verificationKey := "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----"
+
+	tmpDir := "../../build"
+	os.MkdirAll(tmpDir, 0755)
+	outputFile := filepath.Join(tmpDir, "test_output.txt")
+	os.Remove(outputFile)
+
+	err := Output(sealedSecret, decryptionKey, verificationKey, outputFile)
+	assert.NoError(t, err)
+
+	_, statErr := os.Stat(outputFile)
+	assert.NoError(t, statErr)
+
+	content, readErr := os.ReadFile(outputFile)
+	assert.NoError(t, readErr)
+	assert.Contains(t, string(content), "Sealed Secret:")
+	assert.Contains(t, string(content), "SECRET_DECRYPTION_KEY=")
+	assert.Contains(t, string(content), "SECRET_VERIFICATION_KEY=")
+
+	os.Remove(outputFile)
+}
+
+// TestOutput_WithoutFilePath tests Output function without file path (prints to stdout)
+func TestOutput_WithoutFilePath(t *testing.T) {
+	sealedSecret := "sealed-secret-data"
+	decryptionKey := "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+	verificationKey := "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----"
+
+	err := Output(sealedSecret, decryptionKey, verificationKey, "")
+	assert.NoError(t, err)
+}
+
+// TestOutput_InvalidPath tests Output function with invalid file path
+func TestOutput_InvalidPath(t *testing.T) {
+	sealedSecret := "sealed-secret-data"
+	decryptionKey := "test-key"
+	verificationKey := "test-key"
+
+	err := Output(sealedSecret, decryptionKey, verificationKey, testInvalidPath)
+	assert.Error(t, err)
+}
+
+// TestFormatKeyWithEscapedNewlines_WithNewlines tests formatKeyWithEscapedNewlines with newlines
+func TestFormatKeyWithEscapedNewlines_WithNewlines(t *testing.T) {
+	input := "-----BEGIN KEY-----\nline1\nline2\n-----END KEY-----"
+	expected := "-----BEGIN KEY-----\\nline1\\nline2\\n-----END KEY-----"
+	result := formatKeyWithEscapedNewlines(input)
+	assert.Equal(t, expected, result)
+}
+
+// TestFormatKeyWithEscapedNewlines_WithoutNewlines tests formatKeyWithEscapedNewlines without newlines
+func TestFormatKeyWithEscapedNewlines_WithoutNewlines(t *testing.T) {
+	input := "single-line-key"
+	expected := "single-line-key"
+	result := formatKeyWithEscapedNewlines(input)
+	assert.Equal(t, expected, result)
+}
+
+// TestFormatKeyWithEscapedNewlines_EmptyString tests formatKeyWithEscapedNewlines with empty string
+func TestFormatKeyWithEscapedNewlines_EmptyString(t *testing.T) {
+	input := ""
+	expected := ""
+	result := formatKeyWithEscapedNewlines(input)
+	assert.Equal(t, expected, result)
+}
+
+// TestGenerateSealedSecret_EmptySecret tests GenerateSealedSecret with empty secret
+func TestGenerateSealedSecret_EmptySecret(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, inputSha, encryptedSha, err := GenerateSealedSecret("", "env", "", "")
+	assert.Error(t, err)
+	assert.Empty(t, sealedSecret)
+	assert.Empty(t, decryptionKey)
+	assert.Empty(t, verificationKey)
+	assert.Empty(t, inputSha)
+	assert.Empty(t, encryptedSha)
+	assert.Contains(t, err.Error(), "secret cannot be empty")
+}
+
+// TestGenerateSealedSecret_MultilineSecret tests GenerateSealedSecret with multiline secret data
+func TestGenerateSealedSecret_MultilineSecret(t *testing.T) {
+	multilineSecret := "SECRET_VAR1=value1\nSECRET_VAR2=value2\nSECRET_VAR3=value3"
+
+	sealedSecret, decryptionKey, verificationKey, _, _, err := GenerateSealedSecret(multilineSecret, "env", "", "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sealedSecret)
+	assert.NotEmpty(t, decryptionKey)
+	assert.NotEmpty(t, verificationKey)
+}


### PR DESCRIPTION
Created Sealed Secret Flag, Supports sealing of K8s/OCP Secret.

## Description
Contract-go library supports API for sealed secret , Created sealedsecret flag in contract-cli which implements that API and provides tool for of creation sealed secret. 

## Related Issue
Fixes #119 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor

## Testing
Testing is done through UT and tested the contract-cli tool created sealed secret using sealeadsecret flag and tested against the CCCO image . 

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

Assisted-by: IBM Bob
