### PR TITLE
fix: Potential fix for code scanning alert no. 1 - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,8 @@ jobs:
   commit-lint:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/ibm-hyper-protect/contract-cli/security/code-scanning/1](https://github.com/ibm-hyper-protect/contract-cli/security/code-scanning/1)

Add an explicit `permissions` block to the `commit-lint` job in `.github/workflows/build.yaml`.

Best fix without changing functionality: set minimal required permission for that job:
- `contents: read` (sufficient for `actions/checkout` and reading repository content).
- Do not grant write scopes since the job only validates commit messages.

Specific edit:
- File: `.github/workflows/build.yaml`
- Region: `jobs.commit-lint` (just after `if:` and before `steps:`).
- No imports/dependencies/methods needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
