### PR TITLE
feat: Added Initdata Support for CCCO Baremetal Solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This CLI is for **developers, DevOps engineers, and platform teams** who need to
   - Support for password-protected private keys in signing and encryption operations
   - **Specify encryption certificate version** for encryption operations with `--ver` flag
   - Validate contract schemas
-  - Create Gzipped & Encoded initdata for IBM Confidential Computing Containers Peer Pod
+  - Create Gzipped & Encoded initdata for IBM Confidential Computing Containers (Peer Pod and Baremetal solutions)
 
 - **Sealed Secret Management**
   - Generate sealed secrets for CCCO workload and environment sections
@@ -341,9 +341,15 @@ contract-cli validate-contract \
 ### Create initdata annotation from signed & encrypted contract
 
 ```bash
-# Create initdata annotation
+# Create initdata annotation for Peer Pod solution
 contract-cli initdata \
   --in signed_encrypted_contract.yaml
+
+# Create initdata annotation for Baremetal solution with SE header binary
+contract-cli initdata \
+  --in signed_encrypted_contract.yaml \
+  --sehdr se-header.bin \
+  --out initdata.txt
 ```
 
 ### Using Password-Protected Private Keys

--- a/cmd/initdata.go
+++ b/cmd/initdata.go
@@ -29,17 +29,17 @@ var initdataCmd = &cobra.Command{
 	Short: initdata.ParameterShortDescription,
 	Long:  initdata.ParameterLongDescription,
 	Run: func(cmd *cobra.Command, args []string) {
-		inputDataPath, outputPath, err := initdata.ValidateInput(cmd)
+		inputDataPath, sehdrBinPath, outputPath, err := initdata.ValidateInput(cmd)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		gzipInitdata, err := initdata.GenerateInitdata(inputDataPath)
+		gzipInitdata, isBaremetal, err := initdata.GenerateInitdata(inputDataPath, sehdrBinPath)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = initdata.PrintInitdata(gzipInitdata, outputPath)
+		err = initdata.PrintInitdata(gzipInitdata, outputPath, isBaremetal)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -54,6 +54,7 @@ func init() {
 	}
 
 	initdataCmd.PersistentFlags().String(initdata.InputFlagName, "", initdata.InputFlagDescription)
+	initdataCmd.PersistentFlags().String(initdata.SehdrBinFlagName, "", initdata.SehdrBinFlagDescription)
 	initdataCmd.PersistentFlags().String(initdata.OutputFlagName, "", initdata.OutputFlagDescription)
 	common.SetCustomHelpTemplate(initdataCmd, requiredFlags)
 	common.SetCustomErrorTemplate(initdataCmd)

--- a/docs/README.md
+++ b/docs/README.md
@@ -973,7 +973,7 @@ The command outputs:
 ---
 
 ### initdata
-Create initdata annotation from signed and encrypted contract for IBM Confidential Computing Containers for Red Hat OpenShift Container Platform (Peer Pod) solution.
+Create initdata annotation from signed and encrypted contract for IBM Confidential Computing Containers for Red Hat OpenShift Container Platform. Supports both Peer Pod and Baremetal solutions.
 
 #### Usage
 
@@ -986,20 +986,52 @@ contract-cli initdata [flags]
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--in` | string | Yes | Path to signed & encrypted contract YAML file (use '-' for standard input) |
+| `--sehdr` | string | No | Path to SE header binary file (.bin) for baremetal solution |
 | `--out` | string | No | Path to store gzipped & encoded initdata value |
 | `-h, --help` | - | No | Display help information |
 
 #### Examples
 
-**Create initdata from signed & encrypted contract:**
+**Create initdata for Peer Pod solution without SE header binary:**
 ```bash
 contract-cli initdata --in signed_encrypted_contract.yaml
 ```
+
+**Create initdata for Baremetal solution with SE header binary:**
+```bash
+contract-cli initdata \
+  --in signed_encrypted_contract.yaml \
+  --sehdr se-header.bin \
+  --out initdata.txt
+```
+
+**Save output to file for peerpod solution without SE header binary:**
+```bash
+contract-cli initdata \
+  --in signed_encrypted_contract.yaml \
+  --out initdata-annotation.txt
+```
+
+**Save output to file for baremetal solution with SE header binary:**
+```bash
+contract-cli initdata \
+  --in signed_encrypted_contract.yaml \
+  --sehdr se-header.bin \
+  --out initdata-annotation.txt
+```
+
 
 **Using standard input:**
 ```bash
 cat signed_encrypted_contract.yaml | contract-cli initdata --in -
 ```
+
+#### Notes
+
+- With `--sehdr`, the command generates initdata for baremetal solution
+- Without `--sehdr`, the command generates initdata for Peer Pod solution
+- The SE header binary file is automatically encoded to base64 before being included in the initdata
+- Output is gzipped and base64 encoded, ready to use as an initdata annotation
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ibm-hyper-protect/contract-cli
 go 1.26.1
 
 require (
-	github.com/ibm-hyper-protect/contract-go/v2 v2.29.0
+	github.com/ibm-hyper-protect/contract-go/v2 v2.30.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ibm-hyper-protect/contract-go/v2 v2.29.0 h1:WoecJmbPxjO9qDYrmhiv20/We9Ki/1RYMbF47ncM8NM=
-github.com/ibm-hyper-protect/contract-go/v2 v2.29.0/go.mod h1:tbxT+1Xpl4jyYhK2scBO/OTl7/iM2HOoAQxkjdbnY7A=
+github.com/ibm-hyper-protect/contract-go/v2 v2.30.3 h1:17Q431wxtuxTBfQwm8PrcwlwMKtcnAALqFOefsRfBso=
+github.com/ibm-hyper-protect/contract-go/v2 v2.30.3/go.mod h1:/QDRixuFBZcYPkpwqQujd5t6zG3g40k1/1QagFLC7ME=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/lib/initdata/initdata.go
+++ b/lib/initdata/initdata.go
@@ -31,15 +31,18 @@ const (
 	InputFlagName        = "in"
 	InputFlagDescription = "Path of Signed and Encrypted contract (use '-' for standard input)"
 
+	SehdrBinFlagName        = "sehdr"
+	SehdrBinFlagDescription = "Path to SE header binary file (.bin) for baremetal solution"
+
 	OutputFlagName        = "out"
 	OutputFlagDescription = "Path to save Gzipped and encoded initdata value"
 )
 
 // ValidateInput - function to validate inputs of initdata
-func ValidateInput(cmd *cobra.Command) (string, string, error) {
+func ValidateInput(cmd *cobra.Command) (string, string, string, error) {
 	inputData, err := cmd.Flags().GetString(InputFlagName)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
 	if inputData == "" {
@@ -50,15 +53,20 @@ func ValidateInput(cmd *cobra.Command) (string, string, error) {
 	// Validate stdin input
 	common.ValidateStdinInput(cmd, inputData)
 
+	sehdrBinPath, err := cmd.Flags().GetString(SehdrBinFlagName)
+	if err != nil {
+		return "", "", "", err
+	}
+
 	outputPath, err := cmd.Flags().GetString(OutputFlagName)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
-	return inputData, outputPath, nil
+	return inputData, sehdrBinPath, outputPath, nil
 }
 
 // GenerateInitdata - function to generate gzipped initdata
-func GenerateInitdata(inputDataPath string) (string, error) {
+func GenerateInitdata(inputDataPath, sehdrBinPath string) (string, bool, error) {
 	var inputData string
 	var err error
 
@@ -66,33 +74,56 @@ func GenerateInitdata(inputDataPath string) (string, error) {
 	if inputDataPath == "-" {
 		inputData, err = common.ReadDataFromStdin()
 		if err != nil {
-			return "", fmt.Errorf("unable to read input from standard input: %w", err)
+			return "", false, fmt.Errorf("unable to read input from standard input: %w", err)
 		}
 	} else {
 		if !common.CheckFileFolderExists(inputDataPath) {
-			return "", fmt.Errorf("the contract path doesn't exist")
+			return "", false, fmt.Errorf("the contract path doesn't exist")
 		}
 		inputData, err = common.ReadDataFromFile(inputDataPath)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 	}
 
-	gzipInitdata, _, _, err := contract.HpccInitdata(inputData)
-	if err != nil {
-		return "", err
+	// Handle SE header binary file if provided
+	var sehdrBase64 string
+	isBaremetal := false
+	if sehdrBinPath != "" {
+		if !common.CheckFileFolderExists(sehdrBinPath) {
+			return "", false, fmt.Errorf("the SE header binary file path doesn't exist")
+		}
+		binData, err := common.ReadDataFromFile(sehdrBinPath)
+		if err != nil {
+			return "", false, fmt.Errorf("unable to read SE header binary file: %w", err)
+		}
+		// Generate base64 from binary data using HpcrText
+		sehdrBase64, _, _, err = contract.HpcrText(binData)
+		if err != nil {
+			return "", false, fmt.Errorf("unable to encode SE header binary to base64: %w", err)
+		}
+		isBaremetal = true
 	}
-	return gzipInitdata, nil
+
+	gzipInitdata, _, _, err := contract.HpccInitdata(inputData, sehdrBase64)
+	if err != nil {
+		return "", false, err
+	}
+	return gzipInitdata, isBaremetal, nil
 }
 
 // PrintInitdata - function to print generated gzipped initdata value
-func PrintInitdata(gzippedData, outputPath string) error {
+func PrintInitdata(gzippedData, outputPath string, isBaremetal bool) error {
 	if outputPath != "" {
 		err := common.WriteDataToFile(outputPath, gzippedData)
 		if err != nil {
 			return err
 		}
-		fmt.Println("Successfully generated gzipped initdata annotation")
+		if isBaremetal {
+			fmt.Println("Successfully generated gzipped initdata annotation for baremetal solution")
+		} else {
+			fmt.Println("Successfully generated gzipped initdata annotation for peerpod solution")
+		}
 	} else {
 		fmt.Println(gzippedData)
 	}

--- a/lib/initdata/initdata_test.go
+++ b/lib/initdata/initdata_test.go
@@ -17,6 +17,7 @@ package initdata
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -24,24 +25,24 @@ import (
 )
 
 const (
-	testContractPath      = "../../samples/hpcc/signed-encrypt-hpcc.yaml"
-	testOutputPath        = "../../build/test_initdata_output.txt"
-	testInvalidPath       = "../../build/file/file_not_exists.txt"
-	testCorruptedContract = "../../build/corrupted_contract_initdata.yaml"
-	testEmptyContract     = "../../build/empty_contract_initdata.yaml"
-	testTextFile          = "../../build/test_text_file.txt"
+	testContractPath = "../../samples/hpcc/signed-encrypt-hpcc.yaml"
 )
 
 // TestValidateInput_Success tests ValidateInput with all required flags
 func TestValidateInput_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	testOutputPath := filepath.Join(tmpDir, "test_initdata_output.txt")
+
 	cmd := &cobra.Command{}
 	cmd.Flags().String(InputFlagName, testContractPath, "")
+	cmd.Flags().String(SehdrBinFlagName, "", "")
 	cmd.Flags().String(OutputFlagName, testOutputPath, "")
 
-	inputData, outputPath, err := ValidateInput(cmd)
+	inputData, sehdrBinPath, outputPath, err := ValidateInput(cmd)
 
 	assert.NoError(t, err)
 	assert.Equal(t, testContractPath, inputData)
+	assert.Equal(t, "", sehdrBinPath)
 	assert.Equal(t, testOutputPath, outputPath)
 }
 
@@ -49,12 +50,14 @@ func TestValidateInput_Success(t *testing.T) {
 func TestValidateInput_WithoutOutputPath(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().String(InputFlagName, testContractPath, "")
+	cmd.Flags().String(SehdrBinFlagName, "", "")
 	cmd.Flags().String(OutputFlagName, "", "")
 
-	inputData, outputPath, err := ValidateInput(cmd)
+	inputData, sehdrBinPath, outputPath, err := ValidateInput(cmd)
 
 	assert.NoError(t, err)
 	assert.Equal(t, testContractPath, inputData)
+	assert.Equal(t, "", sehdrBinPath)
 	assert.Equal(t, "", outputPath)
 }
 
@@ -67,85 +70,101 @@ func TestValidateInput_FlagErrors(t *testing.T) {
 	cmd := &cobra.Command{}
 	// Don't define flags to trigger errors
 
-	_, _, err := ValidateInput(cmd)
+	_, _, _, err := ValidateInput(cmd)
 
 	assert.Error(t, err)
 }
 
 // TestGenerateInitdata_Success tests successful initdata generation
 func TestGenerateInitdata_Success(t *testing.T) {
-	result, err := GenerateInitdata(testContractPath)
+	result, isBaremetal, err := GenerateInitdata(testContractPath, "")
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
+	assert.False(t, isBaremetal)
 	// Gzipped and base64 encoded data should be a string
 	assert.IsType(t, "", result)
 }
 
 // TestGenerateInitdata_InvalidPath tests with invalid contract path
 func TestGenerateInitdata_InvalidPath(t *testing.T) {
-	result, err := GenerateInitdata(testInvalidPath)
+	tmpDir := t.TempDir()
+	testInvalidPath := filepath.Join(tmpDir, "file", "file_not_exists.txt")
+
+	result, isBaremetal, err := GenerateInitdata(testInvalidPath, "")
 
 	assert.Error(t, err)
 	assert.Equal(t, "", result)
+	assert.False(t, isBaremetal)
 	assert.Contains(t, err.Error(), "doesn't exist")
 }
 
 // TestGenerateInitdata_EmptyPath tests with empty path
 func TestGenerateInitdata_EmptyPath(t *testing.T) {
-	result, err := GenerateInitdata("")
+	result, isBaremetal, err := GenerateInitdata("", "")
 
 	assert.Error(t, err)
 	assert.Equal(t, "", result)
+	assert.False(t, isBaremetal)
 	assert.Contains(t, err.Error(), "doesn't exist")
 }
 
 // TestGenerateInitdata_CorruptedContract tests with corrupted contract file
 // Note: HpccInitdata doesn't validate YAML format, it just gzips and encodes the content
 func TestGenerateInitdata_CorruptedContract(t *testing.T) {
+	tmpDir := t.TempDir()
+	testCorruptedContract := filepath.Join(tmpDir, "corrupted_contract_initdata.yaml")
+
 	err := os.WriteFile(testCorruptedContract, []byte("invalid: yaml: content: ["), 0644)
 	assert.NoError(t, err)
-	defer os.Remove(testCorruptedContract)
 
-	result, err := GenerateInitdata(testCorruptedContract)
+	result, isBaremetal, err := GenerateInitdata(testCorruptedContract, "")
 
 	// HpccInitdata accepts any content and gzips it
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
+	assert.False(t, isBaremetal)
 }
 
 // TestGenerateInitdata_EmptyContract tests with empty contract file
 func TestGenerateInitdata_EmptyContract(t *testing.T) {
+	tmpDir := t.TempDir()
+	testEmptyContract := filepath.Join(tmpDir, "empty_contract_initdata.yaml")
+
 	err := os.WriteFile(testEmptyContract, []byte(""), 0644)
 	assert.NoError(t, err)
-	defer os.Remove(testEmptyContract)
 
-	result, err := GenerateInitdata(testEmptyContract)
+	result, isBaremetal, err := GenerateInitdata(testEmptyContract, "")
 
 	assert.Error(t, err)
 	assert.Equal(t, "", result)
+	assert.False(t, isBaremetal)
 }
 
 // TestGenerateInitdata_NonYamlFile tests with non-YAML file
 // Note: HpccInitdata doesn't validate file format, it just gzips and encodes the content
 func TestGenerateInitdata_NonYamlFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testTextFile := filepath.Join(tmpDir, "test_text_file.txt")
+
 	err := os.WriteFile(testTextFile, []byte("This is just plain text, not a contract"), 0644)
 	assert.NoError(t, err)
-	defer os.Remove(testTextFile)
 
-	result, err := GenerateInitdata(testTextFile)
+	result, isBaremetal, err := GenerateInitdata(testTextFile, "")
 
 	// HpccInitdata accepts any content and gzips it
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
+	assert.False(t, isBaremetal)
 }
 
 // TestPrintInitdata_WithFilePath tests PrintInitdata with valid file path
 func TestPrintInitdata_WithFilePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	testOutputPath := filepath.Join(tmpDir, "test_initdata_output.txt")
 	testData := "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA="
-	os.Remove(testOutputPath)
 
-	err := PrintInitdata(testData, testOutputPath)
+	err := PrintInitdata(testData, testOutputPath, false)
 
 	assert.NoError(t, err)
 
@@ -157,15 +176,13 @@ func TestPrintInitdata_WithFilePath(t *testing.T) {
 	content, readErr := os.ReadFile(testOutputPath)
 	assert.NoError(t, readErr)
 	assert.Equal(t, testData, string(content))
-
-	os.Remove(testOutputPath)
 }
 
 // TestPrintInitdata_WithoutFilePath tests PrintInitdata without file path (prints to stdout)
 func TestPrintInitdata_WithoutFilePath(t *testing.T) {
 	testData := "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA="
 
-	err := PrintInitdata(testData, "")
+	err := PrintInitdata(testData, "", false)
 
 	assert.NoError(t, err)
 }
@@ -175,16 +192,17 @@ func TestPrintInitdata_InvalidPath(t *testing.T) {
 	testData := "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA="
 	invalidPath := "/invalid/directory/that/does/not/exist/output.txt"
 
-	err := PrintInitdata(testData, invalidPath)
+	err := PrintInitdata(testData, invalidPath, false)
 
 	assert.Error(t, err)
 }
 
 // TestPrintInitdata_EmptyData tests PrintInitdata with empty data
 func TestPrintInitdata_EmptyData(t *testing.T) {
-	os.Remove(testOutputPath)
+	tmpDir := t.TempDir()
+	testOutputPath := filepath.Join(tmpDir, "test_initdata_output.txt")
 
-	err := PrintInitdata("", testOutputPath)
+	err := PrintInitdata("", testOutputPath, false)
 
 	assert.NoError(t, err)
 
@@ -192,21 +210,20 @@ func TestPrintInitdata_EmptyData(t *testing.T) {
 	content, readErr := os.ReadFile(testOutputPath)
 	assert.NoError(t, readErr)
 	assert.Equal(t, "", string(content))
-
-	os.Remove(testOutputPath)
 }
 
 // TestPrintInitdata_LargeData tests PrintInitdata with large data
 func TestPrintInitdata_LargeData(t *testing.T) {
+	tmpDir := t.TempDir()
+	testOutputPath := filepath.Join(tmpDir, "test_initdata_output.txt")
+
 	// Create a large base64 string (simulating large gzipped data)
 	largeData := ""
 	for i := 0; i < 1000; i++ {
 		largeData += "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA="
 	}
 
-	os.Remove(testOutputPath)
-
-	err := PrintInitdata(largeData, testOutputPath)
+	err := PrintInitdata(largeData, testOutputPath, false)
 
 	assert.NoError(t, err)
 
@@ -218,16 +235,15 @@ func TestPrintInitdata_LargeData(t *testing.T) {
 	content, readErr := os.ReadFile(testOutputPath)
 	assert.NoError(t, readErr)
 	assert.Equal(t, largeData, string(content))
-
-	os.Remove(testOutputPath)
 }
 
 // TestGenerateInitdata_ValidContract tests with a valid encrypted contract
 func TestGenerateInitdata_ValidContract(t *testing.T) {
-	result, err := GenerateInitdata(testContractPath)
+	result, isBaremetal, err := GenerateInitdata(testContractPath, "")
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
+	assert.False(t, isBaremetal)
 
 	// The result should be base64 encoded gzipped data
 	// It should start with standard gzip base64 prefix
@@ -236,10 +252,11 @@ func TestGenerateInitdata_ValidContract(t *testing.T) {
 
 // TestGenerateInitdata_RelativePath tests with relative path
 func TestGenerateInitdata_RelativePath(t *testing.T) {
-	result, err := GenerateInitdata("../../samples/hpcc/signed-encrypt-hpcc.yaml")
+	result, isBaremetal, err := GenerateInitdata("../../samples/hpcc/signed-encrypt-hpcc.yaml", "")
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
+	assert.False(t, isBaremetal)
 }
 
 // TestGenerateInitdata_AbsolutePath tests with absolute path
@@ -250,10 +267,146 @@ func TestGenerateInitdata_AbsolutePath(t *testing.T) {
 
 	fullPath := absPath + "/../../samples/hpcc/signed-encrypt-hpcc.yaml"
 
-	result, err := GenerateInitdata(fullPath)
+	result, isBaremetal, err := GenerateInitdata(fullPath, "")
 
 	// May fail if path doesn't resolve correctly, but that's okay
 	if err == nil {
 		assert.NotEmpty(t, result)
+		assert.False(t, isBaremetal)
 	}
 }
+
+// TestValidateInput_WithSehdrBin tests ValidateInput with sehdr binary path
+func TestValidateInput_WithSehdrBin(t *testing.T) {
+	tmpDir := t.TempDir()
+	testSehdrBinPath := filepath.Join(tmpDir, "test_sehdr.bin")
+	testOutputPath := filepath.Join(tmpDir, "test_initdata_output.txt")
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String(InputFlagName, testContractPath, "")
+	cmd.Flags().String(SehdrBinFlagName, testSehdrBinPath, "")
+	cmd.Flags().String(OutputFlagName, testOutputPath, "")
+
+	inputData, sehdrBinPath, outputPath, err := ValidateInput(cmd)
+
+	assert.NoError(t, err)
+	assert.Equal(t, testContractPath, inputData)
+	assert.Equal(t, testSehdrBinPath, sehdrBinPath)
+	assert.Equal(t, testOutputPath, outputPath)
+}
+
+// TestGenerateInitdata_WithSehdrBin_Success tests successful initdata generation with SE header binary
+func TestGenerateInitdata_WithSehdrBin_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	testSehdrBinPath := filepath.Join(tmpDir, "test_sehdr.bin")
+
+	// Create a test binary file with some content
+	testBinaryData := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}
+	err := os.WriteFile(testSehdrBinPath, testBinaryData, 0644)
+	assert.NoError(t, err)
+
+	result, isBaremetal, err := GenerateInitdata(testContractPath, testSehdrBinPath)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result)
+	assert.True(t, isBaremetal, "isBaremetal should be true when sehdr binary is provided")
+	// The result should be base64 encoded gzipped data
+	assert.Greater(t, len(result), 10, "Generated initdata should be substantial")
+}
+
+// TestGenerateInitdata_WithSehdrBin_InvalidPath tests with non-existent sehdr binary path
+func TestGenerateInitdata_WithSehdrBin_InvalidPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	testInvalidBinPath := filepath.Join(tmpDir, "file", "invalid_sehdr.bin")
+
+	result, isBaremetal, err := GenerateInitdata(testContractPath, testInvalidBinPath)
+
+	assert.Error(t, err)
+	assert.Equal(t, "", result)
+	assert.False(t, isBaremetal)
+	assert.Contains(t, err.Error(), "doesn't exist", "Error should mention path doesn't exist")
+}
+
+// TestGenerateInitdata_WithSehdrBin_EmptyFile tests with empty sehdr binary file
+func TestGenerateInitdata_WithSehdrBin_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testSehdrBinPath := filepath.Join(tmpDir, "test_sehdr.bin")
+
+	// Create an empty binary file
+	err := os.WriteFile(testSehdrBinPath, []byte{}, 0644)
+	assert.NoError(t, err)
+
+	result, isBaremetal, err := GenerateInitdata(testContractPath, testSehdrBinPath)
+
+	// Empty binary file should cause an error in HpcrText
+	assert.Error(t, err)
+	assert.Equal(t, "", result)
+	assert.False(t, isBaremetal)
+}
+
+// TestGenerateInitdata_WithSehdrBin_LargeBinary tests with large binary file
+func TestGenerateInitdata_WithSehdrBin_LargeBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+	testSehdrBinPath := filepath.Join(tmpDir, "test_sehdr.bin")
+
+	// Create a larger binary file (1KB)
+	largeBinaryData := make([]byte, 1024)
+	for i := range largeBinaryData {
+		largeBinaryData[i] = byte(i % 256)
+	}
+	err := os.WriteFile(testSehdrBinPath, largeBinaryData, 0644)
+	assert.NoError(t, err)
+
+	result, isBaremetal, err := GenerateInitdata(testContractPath, testSehdrBinPath)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result)
+	assert.True(t, isBaremetal)
+	assert.Greater(t, len(result), 100, "Generated initdata with large binary should be substantial")
+}
+
+// TestPrintInitdata_Baremetal tests PrintInitdata with baremetal flag set to true
+func TestPrintInitdata_Baremetal(t *testing.T) {
+	tmpDir := t.TempDir()
+	testOutputPath := filepath.Join(tmpDir, "test_initdata_output.txt")
+	testData := "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA="
+
+	err := PrintInitdata(testData, testOutputPath, true)
+
+	assert.NoError(t, err)
+
+	// Verify file was created
+	_, statErr := os.Stat(testOutputPath)
+	assert.NoError(t, statErr)
+
+	// Verify content
+	content, readErr := os.ReadFile(testOutputPath)
+	assert.NoError(t, readErr)
+	assert.Equal(t, testData, string(content))
+	// Note: The actual "baremetal" message is printed to stdout, not written to file
+	// This test verifies the file writing works correctly with isBaremetal=true
+}
+
+// TestPrintInitdata_Peerpod tests PrintInitdata with baremetal flag set to false
+func TestPrintInitdata_Peerpod(t *testing.T) {
+	tmpDir := t.TempDir()
+	testOutputPath := filepath.Join(tmpDir, "test_initdata_output.txt")
+	testData := "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA="
+
+	err := PrintInitdata(testData, testOutputPath, false)
+
+	assert.NoError(t, err)
+
+	// Verify file was created
+	_, statErr := os.Stat(testOutputPath)
+	assert.NoError(t, statErr)
+
+	// Verify content
+	content, readErr := os.ReadFile(testOutputPath)
+	assert.NoError(t, readErr)
+	assert.Equal(t, testData, string(content))
+	// Note: The actual "peerpod" message is printed to stdout, not written to file
+	// This test verifies the file writing works correctly with isBaremetal=false
+}
+
+// Made with Bob


### PR DESCRIPTION
- Added Flg for providing the encoded sehdrbin in initdata flg

## Description
initdata flag is enhanced to support annotation creation for CCCO baremetal Solution


## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Code refactor

## Testing
Tested the functionality  of initdata flg against CCCO baremetal solution . 


## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
