### PR TITLE
ci: exclude PR checks for renovate & dependabot & add copyright header for files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,18 @@
+# Copyright (c) 2026 IBM Corp.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Bug Report
 description: Report a bug or unexpected behavior in contract-cli
 title: "[Bug]: "

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,18 @@
+# Copyright (c) 2026 IBM Corp.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 blank_issues_enabled: false
 contact_links:
   - name: Documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,18 @@
+# Copyright (c) 2026 IBM Corp.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Feature Request
 description: Suggest a new feature or enhancement for contract-cli
 title: "[Feature]: "

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,3 +1,18 @@
+# Copyright (c) 2026 IBM Corp.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Question / Help
 description: Ask a question or request help using contract-cli
 title: "[Question]: "

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2026 IBM Corp.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 ## Description
 
 <!-- Provide a clear, concise description of the changes in this PR. -->

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,9 @@ on:
 jobs:
   branch-name-check:
     runs-on: ubuntu-latest
+    if: |
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
     permissions:
       contents: read
     steps:
@@ -48,9 +51,10 @@ jobs:
 
   force-push-check:
     runs-on: ubuntu-latest
-    # Only meaningful when a new push updates the PR branch; skip for renovate.
+    # Only meaningful when a new push updates the PR branch; skip for bots.
     if: |
       github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]' &&
       (github.event.action == 'synchronize' || github.event.action == 'reopened')
     permissions:
       contents: read
@@ -92,6 +96,9 @@ jobs:
 
   commit-lint:
     runs-on: ubuntu-latest
+    if: |
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: read
@@ -152,6 +159,9 @@ jobs:
 
   verify-commit-signatures:
     runs-on: ubuntu-latest
+    if: |
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
     permissions:
       contents: read
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+# Copyright (c) 2026 IBM Corp.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build artifacts
 build/
 dist/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2026 IBM Corp.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2026 IBM Corp.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Contributing to contract-cli
 
 Thank you for considering contributing to `contract-cli`! We appreciate your time and effort in helping improve this project. This guide will help you understand our development process and how to contribute effectively.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2026 IBM Corp.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Maintainers
 
 This document lists the maintainers of the `contract-cli` project, their roles, and responsibilities.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2026 IBM Corp.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Contract CLI
 
 [![Build & Test](https://github.com/ibm-hyper-protect/contract-cli/actions/workflows/build.yml/badge.svg)](https://github.com/ibm-hyper-protect/contract-cli/actions/workflows/build.yml)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2026 IBM Corp.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Security Policy
 
 ## Supported Versions

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2026 IBM Corp.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Contract CLI Documentation
 
 Complete command reference and usage guide for the IBM Confidential Computing Contract CLI.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,18 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module github.com/ibm-hyper-protect/contract-cli
 
 go 1.26.4

--- a/lib/signContract/signContract.go
+++ b/lib/signContract/signContract.go
@@ -1,3 +1,18 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package signContract
 
 import (


### PR DESCRIPTION
## Description

<!-- Provide a clear, concise description of the changes in this PR. -->
* Exclude PR checks for renovate & dependabot users.
* Add copyright headers for files that dont have copyright.

## Related Issue

<!-- Link the issue this PR addresses. Use "Fixes #123" to auto-close the issue on merge. -->

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactor (no functional changes)
- [x] CI/CD or build changes

## Target Platform

<!-- Which IBM Confidential Computing platform(s) does this affect? -->

- [ ] HPVS (IBM Hyper Protect Virtual Servers for VPC)
- [ ] CCRT (IBM Confidential Computing Container Runtime)
- [ ] CCRV (IBM Confidential Computing Container Runtime for Red Hat Virtualization Solutions)
- [ ] CCCO (IBM Confidential Computing Containers for Red Hat OpenShift Container Platform)
- [ ] All platforms
- [x] Not platform-specific

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] `make test` passes
- [ ] `make fmt` applied (no formatting changes needed)
- [ ] New tests added for new functionality (if applicable)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have added/updated GoDoc comments for public functions
- [ ] I have updated documentation (README, docs/README.md) if needed
- [ ] All new and existing tests pass (`make test`)
- [ ] I have verified there are no breaking changes (or documented them above)
